### PR TITLE
Fixes #32: ci.sh exits with error if no -r MODE option

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -190,4 +190,6 @@ else
 
   # Run containers in MODE, if -r specified
   [ -n "${MODE}" ] && runContainers
+
+  exit 0
 fi


### PR DESCRIPTION
## Description

This PR fixes #32 

## Testing

- [ ] Locally, followed steps in Issue to confirm script exits with success
   <details>
   
    ![image](https://github.com/user-attachments/assets/2705ced6-e761-4794-a0eb-4bac6620c761)
   </details>
   
- [ ] Checked branch out in super project to confirm it didn't fail in the workflow which exposed the issue in the first place
   <details>
   
   ![image](https://github.com/user-attachments/assets/fca18c67-26bf-45e6-8de2-d0eb78f7948a)   
   </details>