### PR TITLE
Fixes #31, #35, #34: Add ci.sh push support, sample workflows, update docs

### DIFF
--- a/.github/workflows/samples/README.md
+++ b/.github/workflows/samples/README.md
@@ -7,11 +7,13 @@ bitwarden-directory-connector-containers is a submodule.
 
 | Workflow | Action | When | Notes |
 | --- | --- | --- | --- |
-| [build-all-typed-images.yml] | Builds one typed images per `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` using [`ci.sh`] | - PRs to main<BR>- On demand | Just building the images isn't really helpful without pushing them, unless you are testing changes to your conf files and want to know they will work when you do push. |
+| [build-all-typed-images.yml] | Builds one typed image per `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` using [`ci.sh`] | - PRs to main<BR>- On demand | Just building the images is not really helpful without pushing them, unless you are testing changes to your conf files and want to know they will work when you do push. |
+| [build-and-push-all-typed-images.yml] | Builds one typed image per `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` and pushes all `bwdc-*` images to `$IMAGE_NAMESPACE` using [`ci.sh`] | On demand | Ideal job to run as needed to get your images built and pushed to your container registry.<BR><BR>By default, this uses `github.actor` and `github.token` to login to the container registry. If these will not work for you, you will need to edit the workflow file. There are commented out examples for using Github Secrets included. |
 
 <!-- Links -->
-[build-all-typed-images.yml]:     ./build-all-typed-images.yml
-[`ci.sh`]:                        ../../../ci.sh
+[build-all-typed-images.yml]:          ./build-all-typed-images.yml
+[build-and-push-all-typed-images.yml]: ./build-and-push-all-typed-images.yml
+[`ci.sh`]:                             ../../../ci.sh
 
 <!-- markdownlint-configure-file {
  MD033: false

--- a/.github/workflows/samples/README.md
+++ b/.github/workflows/samples/README.md
@@ -1,20 +1,32 @@
 # Superproject workflow samples
 
-The workflows in this subdirectory should not appear in the main
-bitwarden-directory-connector-container Actions because subdirectories are not
-supported. These are meant to be copied to a superproject where
-bitwarden-directory-connector-containers is a submodule.
+These workflows should be copied to a superproject where
+`bitwarden-directory-connector-containers` is a submodule. Place them in
+`$YOUR_PROJECT_REPO_NAME/.github/workflows` to have them appear on the Actions
+tab of your superproject.
+
+> [!TIP]
+> You will need to set the secrets specified in [managing-secrets.md] in your
+[Github repository secrets] settings to successfully execute the workflows.
+<!-- markdownlint-disable-next-line no-blanks-blockquote -->
+> [!NOTE]
+> The workflows in this subdirectory should not appear in the main
+`bitwarden-directory-connector-container` Actions because subdirectories are not
+supported.
 
 | Workflow | Action | When | Notes |
 | --- | --- | --- | --- |
-| [build-all-typed-images.yml] | Builds one typed image per `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` using [`ci.sh`] | - PRs to main<BR>- On demand | Just building the images is not really helpful without pushing them, unless you are testing changes to your conf files and want to know they will work when you do push. |
-| [build-and-push-all-typed-images.yml] | Builds one typed image per `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` and pushes all `bwdc-*` images to `$IMAGE_NAMESPACE` using [`ci.sh`] | On demand | Ideal job to run as needed to get your images built and pushed to your container registry.<BR><BR>By default, this uses `github.actor` and `github.token` to login to the container registry. If these will not work for you, you will need to edit the workflow file. There are commented out examples for using Github Secrets included. |
+| [build-all-typed-images.yml] | Builds one typed image per `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` using [`ci.sh`]`-b` | - PRs to main<BR>- On demand | Just building the images is not really helpful without pushing them, unless you are testing changes to your conf files and want to know they will work when you do push. |
+| [build-and-push-all-typed-images.yml] | Builds one typed image per `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` and pushes all `bwdc-*` images to `$IMAGE_NAMESPACE` using [`ci.sh`]`-b -p` | On demand | Ideal job to run as needed to get your images built and pushed to your container registry.<BR><BR>By default, this uses `github.actor` and `github.token` to login to the container registry. If these will not work for you, you will need to edit the workflow file. There are commented out examples for using Github Secrets included. |
+| [run-all-typed-images.yml] | Runs each container matching to the `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` files using [`ci.sh`]`-r MODE`| On demand (with input) | Options are `config`, `test` and `sync`, and behave the same as they would for `-r MODE` with [`ci.sh`] |
 
 <!-- Links -->
 [build-all-typed-images.yml]:          ./build-all-typed-images.yml
 [build-and-push-all-typed-images.yml]: ./build-and-push-all-typed-images.yml
+[run-all-typed-images.yml]:            ./run-all-typed-images.yml
 [`ci.sh`]:                             ../../../ci.sh
-
+[managing-secrets.md]:                 ../../../docs/managing-secrets.md
+[Github repository secrets]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
 <!-- markdownlint-configure-file {
  MD033: false
 }

--- a/.github/workflows/samples/README.md
+++ b/.github/workflows/samples/README.md
@@ -1,0 +1,19 @@
+# Superproject workflow samples
+
+The workflows in this subdirectory should not appear in the main
+bitwarden-directory-connector-container Actions because subdirectories are not
+supported. These are meant to be copied to a superproject where
+bitwarden-directory-connector-containers is a submodule.
+
+| Workflow | Action | When | Notes |
+| --- | --- | --- | --- |
+| [build-all-typed-images.yml] | Builds one typed images per `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` using [`ci.sh`] | - PRs to main<BR>- On demand | Just building the images isn't really helpful without pushing them, unless you are testing changes to your conf files and want to know they will work when you do push. |
+
+<!-- Links -->
+[build-all-typed-images.yml]:     ./build-all-typed-images.yml
+[`ci.sh`]:                        ../../../ci.sh
+
+<!-- markdownlint-configure-file {
+ MD033: false
+}
+-->

--- a/.github/workflows/samples/build-all-typed-images.yml
+++ b/.github/workflows/samples/build-all-typed-images.yml
@@ -1,0 +1,30 @@
+name: Build All Typed Images
+description: Build all bwdc-$TYPE-$CONFNAME images
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - 'custom.conf'
+      - 'gsuite/*.conf'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-bwdc-typed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
+        with:
+          submodules: true
+
+      - name: Build all typed images using ci.sh
+        env:
+          BW_CLIENTID: ${{ secrets.BW_CLIENTID }}
+          BW_CLIENTSECRET: ${{ secrets.BW_CLIENTSECRET }}
+        run: $GITHUB_WORKSPACE/bitwarden-directory-connector-containers/ci.sh -b

--- a/.github/workflows/samples/build-and-push-all-typed-images.yml
+++ b/.github/workflows/samples/build-and-push-all-typed-images.yml
@@ -1,0 +1,32 @@
+name: Build and Push All Typed Images
+description: Build and push all bwdc-$TYPE-$CONFNAME images
+
+env:
+  # The following two should work as is for pushing to ghcr.io
+  REGISTRY_USER: ${{ github.actor }}
+  REGISTRY_PASSWORD: ${{ github.token }}
+  # Use and update the following for other registries
+  #REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
+  #REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push-bwdc-typed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
+        with:
+          submodules: true
+
+      - name: Build and push all typed images using ci.sh
+        env:
+          BW_CLIENTID: ${{ secrets.BW_CLIENTID }}
+          BW_CLIENTSECRET: ${{ secrets.BW_CLIENTSECRET }}
+        run: $GITHUB_WORKSPACE/bitwarden-directory-connector-containers/ci.sh -b -p

--- a/.github/workflows/samples/run-all-typed-images.yml
+++ b/.github/workflows/samples/run-all-typed-images.yml
@@ -1,0 +1,45 @@
+name: Run All Typed Images
+description: Run all bwdc-$TYPE-$CONFNAME images
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_mode:
+        required: true
+        default: 'test'
+        type: choice
+        options:
+          - config
+          - test
+          - sync
+
+# The Github Action will not fail for unset secrets, so if you see some here
+# for a type you are not using, it will not hurt to leave it
+env:
+  BW_CLIENTID: ${{ secrets.BW_CLIENTID }}
+  BW_CLIENTSECRET: ${{ secrets.BW_CLIENTSECRET }}
+  BW_GSUITEKEY: ${{ secrets.BW_GSUITEKEY }}
+  # The following two should work as is for pulling from ghcr.io
+  REGISTRY_USER: ${{ github.actor }}
+  REGISTRY_PASSWORD: ${{ github.token }}
+  # Use and update the following for other registries
+  #REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
+  #REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  run-all-typed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
+        with:
+          submodules: true
+
+      - name: Run all typed images using ci.sh with the mode specified
+        run: $GITHUB_WORKSPACE/bitwarden-directory-connector-containers/ci.sh -r ${{ inputs.run_mode }}
+

--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ version of the steps below.
       ```bash
       # EXAMPLE WHEN USED AS SUBMODULE
       # Use -h for all options with full descriptions
-      # USAGE: ci.sh [-b] [-r config|test|sync] [-p CONFS_DIR] [-s]
+      # USAGE: ci.sh [-b] [-r config|test|sync] [-d CONFS_DIR] [-s]
       ./bitwarden-directory-connector-containers/ci.sh -b -r test
       ```
       ```bash
       # EXAMPLE FROM THIS PROJECT'S DIRECTORY (no submodule):
       # Use -h for all options with full descriptions
-      # USAGE: ci.sh [-b] [-r config|test|sync] [-p CONFS_DIR] [-s]
-      ./ci.sh -p $PWD -b -r test
+      # USAGE: ci.sh [-b] [-r config|test|sync] [-d CONFS_DIR] [-s]
+      ./ci.sh -d $PWD -b -r test
       ```
     b. **_IF YOU ONLY WANT TO BUILD THE IMAGES OF ONE TYPE AND TEST BWDC
     LOGIN/LOGOUT_**: Run the [`build-typed-images.sh`] script once per

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ related to, files they depend on and links to documentation that explain them.
 | Build the `bwdc-base` image, which is the root of the rest of the containers. Published by @hdub-tech to [GitHub packages for this project]. | [`build-base-image.sh`] | - [`Containerfile`]<BR>- [`defaults.conf`] / `custom.conf`<BR>- [`build-push-base.yml`] | [base-image.md] |
 | The [`ENTRYPOINT`] of the `bwdc-base` image, and therefore all typed images built off of it. | [`entrypoint.sh`] | N/A | [base-image.md] |
 | Build per-configuration file images, one type per run, optionally without using the podman cache and optionally testing login even if the image was already built. | [`build-typed-images.sh`] | - [`defaults.conf`] / `custom.conf`<BR>- `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE/Containerfile` ([`gsuite` Containerfile], as an example)<BR>- `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE/$CONFNAME.conf` ([`gsuite` argfile template], as an example) | - [config-files.md]<BR>- [managing-secrets.md]<BR>- [typed-images.md] |
-| Install/verify dependencies (optional), build all images of all types (EXCEPT the bwdc-base) and/or run all the images. | [`ci.sh`] | - [`defaults.conf`] / `custom.conf`<BR>- `*/Containerfile` ([`gsuite` Containerfile], as an example)<BR>- `*/$CONFNAME.conf` ([`gsuite` argfile template], as an example) | -[config-files.md]<BR>- [typed-images.md] |
+| Install/verify dependencies (optional), build all images of all types (EXCEPT the bwdc-base) and/or push and/or run all the images. | [`ci.sh`] | - [`defaults.conf`] / `custom.conf`<BR>- `*/Containerfile` ([`gsuite` Containerfile], as an example)<BR>- `*/$CONFNAME.conf` ([`gsuite` argfile template], as an example) | - [config-files.md]<BR>- [typed-images.md] |
 | Utility functions used by other scripts | [`functions.sh`] | N/A | N/A |
 
 ## Requirements
@@ -131,13 +131,13 @@ version of the steps below.
       ```bash
       # EXAMPLE WHEN USED AS SUBMODULE
       # Use -h for all options with full descriptions
-      # USAGE: ci.sh [-b] [-r config|test|sync] [-d CONFS_DIR] [-s]
+      # USAGE: ci.sh [-b] [-p] [-r config|test|sync] [-d CONFS_DIR] [-s]
       ./bitwarden-directory-connector-containers/ci.sh -b -r test
       ```
       ```bash
       # EXAMPLE FROM THIS PROJECT'S DIRECTORY (no submodule):
       # Use -h for all options with full descriptions
-      # USAGE: ci.sh [-b] [-r config|test|sync] [-d CONFS_DIR] [-s]
+      # USAGE: ci.sh [-b] [-p] [-r config|test|sync] [-d CONFS_DIR] [-s]
       ./ci.sh -d $PWD -b -r test
       ```
     b. **_IF YOU ONLY WANT TO BUILD THE IMAGES OF ONE TYPE AND TEST BWDC

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project has two sets of container images:
   the [Github packages for this project] (See [base-image.md] for details).
 * The "typed images", which are built off of [`bwdc-base`] and is specific to a
   Directory Connector type, often abbreviated here as
-  `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE` (See [typed-images.md] for details).
+  `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE` (See [typed-images.md] for details).
 
 > [!NOTE]
 > Project currently only supports the Gsuite directory connector type for the
@@ -53,7 +53,7 @@ related to, files they depend on and links to documentation that explain them.
 | --- | --- | --- | --- |
 | Build the `bwdc-base` image, which is the root of the rest of the containers. Published by @hdub-tech to [GitHub packages for this project]. | [`build-base-image.sh`] | - [`Containerfile`]<BR>- [`defaults.conf`] / `custom.conf`<BR>- [`build-push-base.yml`] | [base-image.md] |
 | The [`ENTRYPOINT`] of the `bwdc-base` image, and therefore all typed images built off of it. | [`entrypoint.sh`] | N/A | [base-image.md] |
-| Build per-configuration file images, one type per run, optionally without using the podman cache and optionally testing login even if the image was already built. | [`build-typed-images.sh`] | - [`defaults.conf`] / `custom.conf`<BR>- `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE/Containerfile` ([`gsuite` Containerfile], as an example)<BR>- `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE/$CONFNAME.conf` ([`gsuite` argfile template], as an example) | - [config-files.md]<BR>- [managing-secrets.md]<BR>- [typed-images.md] |
+| Build per-configuration file images, one type per run, optionally without using the podman cache and optionally testing login even if the image was already built. | [`build-typed-images.sh`] | - [`defaults.conf`] / `custom.conf`<BR>- `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/Containerfile` ([`gsuite` Containerfile], as an example)<BR>- `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/$CONFNAME.conf` ([`gsuite` argfile template], as an example) | - [config-files.md]<BR>- [managing-secrets.md]<BR>- [typed-images.md] |
 | Install/verify dependencies (optional), build all images of all types (EXCEPT the bwdc-base) and/or push and/or run all the images. | [`ci.sh`] | - [`defaults.conf`] / `custom.conf`<BR>- `*/Containerfile` ([`gsuite` Containerfile], as an example)<BR>- `*/$CONFNAME.conf` ([`gsuite` argfile template], as an example) | - [config-files.md]<BR>- [typed-images.md] |
 | Utility functions used by other scripts | [`functions.sh`] | N/A | N/A |
 
@@ -90,8 +90,8 @@ version of the steps below.
    cp defaults.conf custom.conf
    ```
 
-2. Copy the `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE/argfile.conf.template` to
-   `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE/$DESCRIPTIVE_NAME.conf` and update
+2. Copy the `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/argfile.conf.template` to
+   `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/$DESCRIPTIVE_NAME.conf` and update
    the conf file for your sync needs. This template contains detailed comments
    on what and how to update. (Detailed documentation at [config-files.md]). Do
    this once per sync profile / data.json file.
@@ -108,7 +108,7 @@ version of the steps below.
    ```
 
 3. Export your `BW_CLIENTID` and `BW_CLIENTSECRET`, as well as any type specific
-   secrets specified in `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE/env.vars`
+   secrets specified in `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/env.vars`
    ([`gsuite` env sample]) (Detailed documentation: [managing-secrets.md]).
    ```bash
    # EXAMPLE (disabling history for commands with leading spaces, then issue exports with a leading space)
@@ -142,7 +142,7 @@ version of the steps below.
       ```
     b. **_IF YOU ONLY WANT TO BUILD THE IMAGES OF ONE TYPE AND TEST BWDC
     LOGIN/LOGOUT_**: Run the [`build-typed-images.sh`] script once per
-    `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE`, to build one image per config
+    `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE`, to build one image per config
     file and run `bwdc login` and `bwdc logout`, which is necesary for the
     build image process. No secrets will be stored to disk or in the
     environment of the produced image (Detailed documentation:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ version of the steps below.
       ./build-typed-images.sh -t gsuite
       ```
 
+5. Copy the desired workflows to use in your superproject (Detailed
+   [sample workflows documentation]):
+   ```bash
+   # From $YOUR_PROJECT_REPO, where bitwarden-directory-connector-containers is a submodule
+   mkdir --parents .github/workflows
+   cp ./bitwarden-directory-connector-containers/.github/workflows/samples/*.yml ./.github/workflows/
+   ```
+
 ## License(s)
 
 * [This project's license] (GNU GPL Version 3)
@@ -210,6 +218,7 @@ Please see the [SECURITY.md] guide for details.
 [licenses]:                         ./licenses/
 [SECURITY.md]:                      ./docs/SECURITY.md
 [managing-secrets.md]:              ./docs/managing-secrets.md
+[sample workflows documentation]:   ./.github/workflows/samples/README.md
 [This project's license]:           ./LICENSE
 [typed-images.md]:                  ./docs/typed-images.md
 [`bwdc`]:                           https://bitwarden.com/help/directory-sync-cli

--- a/ci.sh
+++ b/ci.sh
@@ -192,6 +192,8 @@ runContainers() {
     "sync"   ) ENTRYPOINT_OPTS="-c -t -s" ;;
   esac
 
+  [ "localhost" != "${REGISTRY}" ] && podmanLogin
+
   for type in "${SUPPORTED_BWDC_TYPES[@]}"; do
     if [ -d "${PROJECT_CONFS_DIR}/${type}" ]; then
       message "${SCRIPT_NAME}" "INFO" "Running images of type [${type}]"
@@ -208,6 +210,11 @@ runContainers() {
       message "${SCRIPT_NAME}" "INFO" "No images of type [${type}] in [${PROJECT_CONFS_DIR}]...skipping"
     fi
   done
+
+  # NOTE: I'm aware this will not logout if podman run encounters an error.
+  # Rather than trying every image like I did with push, I'd rather exit to
+  # investigate. Risks are higher on run than push.
+  podmanLogout
 }
 
 while getopts "bpd:r:sh" opt; do

--- a/ci.sh
+++ b/ci.sh
@@ -12,27 +12,33 @@ MINIMUM_PODMAN_VERSION="4.5.0"
 
 # Configurable args
 PROJECT_CONFS_DIR="${DEFAULT_PROJECT_CONFS_DIR}"
+BUILD_TYPED_IMAGES=
+PUSH_TYPED_IMAGES=
 MODE=
 SKIP_PREREQS=
 IMAGE_NAMESPACE=
 
 usage() {
    cat <<EOM
+
   DESCRIPTION:
-    A script which will build multiple images of multiple types as a sort
-    of one stop shop for doing all of your bwdc syncs (or even just test).
+    A script which will build and/or push multiple images of multiple types as a
+    one stop shop for doing all of your bwdc syncs (or even just test).
     This github project should be a submodule of your project of confs.
     This script was designed with simplification for CI and workflows in mind.
 
 >>> (!) WARNING: THIS SCRIPT WILL INSTALL REQUIRED PACKAGES UNLESS RUN WITH -s (!) <<<
 
   USAGE:
-    ${0} -b|-r MODE [-d PROJECT_CONFS_DIR] [-s]
+    ${0} -b|-p|-r MODE [-d PROJECT_CONFS_DIR] [-s]
 
   Where:
-    * -b and/or -r MODE is specified.
+    * At least one of -b and/or -p and/or -r MODE is specified.
     * -b: Builds all of your typed containers. You can skip this if you already
       have the images built and published somewhere accessible by this script.
+    * -p: Push all \$IMAGE_NAMESPACE/bwdc-* images. If you are not already
+      logged into your container registry, set the REGISTRY_USER and
+      REGISTRY_PASSWORD environment variables and it will be done for you.
     * -r MODE is one of:
       * config: Runs each container, finishing the necessary configuration using
         the secrets provided
@@ -116,6 +122,59 @@ buildImages() {
   podman image ls "${IMAGE_NAMESPACE}"/*
 }
 
+# Push all IMAGE_NAMESPACE/bwdc-* images to registry
+pushImages() {
+  registry="${IMAGE_NAMESPACE%/*}"
+  if [ "localhost" == "${registry}" ]; then
+    message "${SCRIPT_NAME}" "WARN" "IMAGE_NAMESPACE is localhost - skipping push to registry!"
+  else
+    ci_podman_auth=
+    # If not logged in, attempt to login to registry with env variables
+    if ! podman login --get-login "${registry}" &>/dev/null; then
+      message "${SCRIPT_NAME}" "WARN" "Not logged into ${registry}. Attempting login using \${REGISTRY_USER} and \${REGISTRY_PASSWORD} environment variables"
+
+      set +x  # Make extra sure no output
+      if [ -n "${REGISTRY_USER}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
+        echo "${REGISTRY_PASSWORD}" | podman login "$registry" --username "${REGISTRY_USER}" --password-stdin && ci_podman_auth=true
+      fi
+
+      if ! podman login --get-login "${registry}" &>/dev/null; then
+        message "${SCRIPT_NAME}" "ERROR" "podman login failed. Please run podman login manually, or set REGISTRY_USER and REGISTRY_PASSWORD environment variables and re-run this script"
+        usage 9
+      fi
+    fi
+
+    # Should be logged in, get all relevant images and push
+    image_prefix="${IMAGE_NAMESPACE}"/bwdc
+    bwdc_images="$( podman image ls --filter=reference="${image_prefix}-*" --noheading --format "table {{.Repository}}:{{.Tag}}" )"
+    declare -a ci_push_failures
+    if [ -n "${bwdc_images}" ]; then
+      for bwdc_image in ${bwdc_images}; do
+        # podman image ls will return images which do NOT match the reference
+        # if they are tagged from an image that DOES match the reference. This
+        # prevents incidentals
+        if [ "${bwdc_image#"$image_prefix"}" != "${bwdc_image}" ]; then
+          message "${SCRIPT_NAME}" "INFO" "Pushing [${bwdc_image}] to [$registry]"
+	  podman push "${bwdc_image}" || ci_push_failures+=("${bwdc_image} ")
+        else
+          message "${SCRIPT_NAME}" "WARN" "[${bwdc_image}] not prefixed with [${image_prefix}]...skipping push."
+        fi
+      done
+    else
+      message "${SCRIPT_NAME}" "WARN" "No [${image_prefix}-*] images to push!"
+    fi
+
+    # Always logout if we were the one to login
+    [ -n "${ci_podman_auth}" ] && podman logout "${registry}"
+
+    # Exit with error if we had push failures
+    if [ "${#ci_push_failures}" -gt 0 ]; then
+      message "${SCRIPT_NAME}" "ERROR" "Errors pushing the following images: ${ci_push_failures[*]}"
+      exit 12
+    fi
+  fi
+}
+
 # Run each container in the mode specified
 runContainers() {
   ENTRYPOINT_OPTS=
@@ -143,11 +202,15 @@ runContainers() {
   done
 }
 
-while getopts "bd:r:sh" opt; do
+while getopts "bpd:r:sh" opt; do
   case "${opt}" in
     "b" )
       # b = build typed images
       BUILD_TYPED_IMAGES="true"
+      ;;
+    "p" )
+      # p = push images
+      PUSH_TYPED_IMAGES="true"
       ;;
     "d" )
       # d = dir for project confs
@@ -170,7 +233,7 @@ while getopts "bd:r:sh" opt; do
   esac
 done
 
-if [ -z "${BUILD_TYPED_IMAGES}" ] && [ -z "${MODE}" ]; then
+if [ -z "${BUILD_TYPED_IMAGES}" ] && [ -z "${PUSH_TYPED_IMAGES}" ] && [ -z "${MODE}" ]; then
   usage 3
 else
   # If -s wasn't specified, install pre-reqs
@@ -187,6 +250,9 @@ else
 
   # Build typed images, if -b specified
   [ -n "${BUILD_TYPED_IMAGES}" ] && buildImages
+
+  # Push IMAGE_NAMESPACE/bwdc-* images, if -p specified
+  [ -n "${PUSH_TYPED_IMAGES}" ] && pushImages
 
   # Run containers in MODE, if -r specified
   [ -n "${MODE}" ] && runContainers

--- a/ci.sh
+++ b/ci.sh
@@ -27,7 +27,7 @@ usage() {
 >>> (!) WARNING: THIS SCRIPT WILL INSTALL REQUIRED PACKAGES UNLESS RUN WITH -s (!) <<<
 
   USAGE:
-    ${0} -b|-r MODE [-p PROJECT_CONFS_DIR] [-s]
+    ${0} -b|-r MODE [-d PROJECT_CONFS_DIR] [-s]
 
   Where:
     * -b and/or -r MODE is specified.
@@ -143,14 +143,14 @@ runContainers() {
   done
 }
 
-while getopts "bp:r:sh" opt; do
+while getopts "bd:r:sh" opt; do
   case "${opt}" in
     "b" )
       # b = build typed images
       BUILD_TYPED_IMAGES="true"
       ;;
-    "p" )
-      # p = project dir
+    "d" )
+      # d = dir for project confs
       [ ! -d "${OPTARG}" ] && message "${SCRIPT_NAME}" "ERROR" "Directory does not exist: ${OPTARG}" && usage 8
       PROJECT_CONFS_DIR=$( cd "${OPTARG}" && pwd )
       ;;

--- a/defaults.conf
+++ b/defaults.conf
@@ -25,4 +25,4 @@ SECRETS_MANAGER=env
 
 # The namespace for all images to be built from
 # (See docs/base-image.md, docs/typed-images.md)
-IMAGE_NAMESPACE=ghcr.io/hdub-tech
+IMAGE_NAMESPACE=localhost

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -78,6 +78,10 @@ advanced users and includes a description of the variables contained within
 and where/how they are used.
 
 > [!WARNING]
+> If you plan to push images to a registry, you must set `IMAGE_NAMESPACE`
+to match your registry in `custom.conf`!
+<!-- markdownlint-disable-next-line no-blanks-blockquote -->
+> [!WARNING]
 > Do not edit `defaults.conf` directly! Instead, COPY `defaults.conf` to
 `custom.conf` and update that file.
 
@@ -87,7 +91,7 @@ and where/how they are used.
 | `BDCC_VERSION` | X.Y.Z | Building typed images: <UL><LI>[Any tag for this project] (no leading 'v')</LI></UL>Building `bwdc-base` image<UL><LI>Follow [Semantic versioning]</LI></UL> | This is for: <UL><LI> Maintainers to tag and release `bwdc-base` tied to the Github project release version</LI><LI>Users who are uncomfortable with image tags being rewritten (Again, I get it, I am you). See also `USE_BDCC_VERSION_FOR_TYPED`</LI></UL> |
 | `USE_BDCC_VERSION_FOR_TYPED` | Boolean | <UL><LI>false (default)</LI><LI>true</LI></UL> | Set this to `true` if you want to pull the `bwdc-base` image using the `BDCC_VERSION` tag instead of the `BWDC_VERSION` tag when running [`build-typed-images.sh`].<BR><BR>I initially designed the tagging of `bwdc-base` with simplicity and convenience in mind - users would only need to know the version of `bwdc` they cared about, and that would be the tag. However, when I found [the first real bug], I realized I would have to republish the `bwdc-base` image, and if I tagged only on the version of `bwdc`, I would be overwriting an existing tagged image. Being a security minded person myself, I knew I would HATE being on the receiving end of that without at least an OPTION to control it. In my defense, I was additionally tagging `bwdc-base` with the git ref, but I didn't implement any way for users to utilize that, plus a sha isn't exactly a user friendly format. So tagging based on the release and adding this boolean is the best I could come up with on short notice. |
 | `SECRETS_MANAGER` | String | <UL><LI>env</LI><LI>~podman~</LI></UL> | When running [`build-typed-images.sh`] or [`ci.sh`]`-r MODE`, this specifies how you are managing the secrets which will be used when the container is run (See [managing-secrets.md] for details). |
-| `IMAGE_NAMESPACE` | [REGISTRY/]NAMESPACE | Examples: <LI>ghcr.io/hdub-tech</LI><LI>docker.io/orgname</LI><LI>orgname (registry defaults to localhost)</LI> | The namespace (optionally with registry) of the [`build-typed-images.sh`] / [`ci.sh`]`-b` generated images.<BR>NO IMAGES ARE PUSHED IN ANY OF THESE SCRIPTS, so this is for local tagging purposes only (See [typed-images.md] for details). |
+| `IMAGE_NAMESPACE` | REGISTRY/NAMESPACE | Examples: <LI>ghcr.io/hdub-tech</LI><LI>docker.io/orgname</LI><LI>localhost/orgname</LI> | The registry/namespace of the [`build-typed-images.sh`] / [`ci.sh`]`[-b\|-p]` generated/pushed images.<BR>Images are ONLY pushed with the `-p` option on `ci.sh`(See [typed-images.md] for details). |
 
 ## `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/argfile.conf.template`
 

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -30,11 +30,15 @@ for your project should be as follows:
 ```bash
 YOUR_PROJECT_REPO_NAME
 ├── custom.conf
-├── gsuite
+├── gsuite/
 │   ├── administration.conf
 │   ├── sales.conf
 │   └──  ...
-└── bitwarden-directory-connector-containers   # <-- [git submodule]
+├── .github/workflows/  # Copy from this project's .github/workflows/samples
+|   ├── build-all-typed-images.yml
+|   ├── build-and-push-all-typed-images.yml
+|   └── run-all-typed-images.yml
+└── bitwarden-directory-connector-containers/   # <-- [git submodule]
 ```
 
 ### Adding bitwarden-directory-connector-containers as a submodule

--- a/docs/managing-secrets.md
+++ b/docs/managing-secrets.md
@@ -36,6 +36,7 @@ free to open an issue if you are interested in seeing that feature.
    | `BW_CLIENTID` | All | - [`build-typed-images.sh`]<BR>- [`ci.sh`]<BR>- `podman run hdub-tech/bwdc-base` <BR>- `podman run bwdc-$TYPE-$CONF` | Format: `organization.UUID`<BR>Found in [Bitwarden Admin Console]. |
    | `BW_CLIENTSECRET` | All | - [`build-typed-images.sh`]<BR>- [`ci.sh`]<BR>- `podman run hdub-tech/bwdc-base`<BR>- `podman run bwdc-$TYPE-$CONF`  | Format: alphanumeric<BR>Found in [Bitwarden Admin Console]. |
    | `BW_GSUITEKEY` | Gsuite | - [`ci.sh`]<BR>- `podman run bwdc-$TYPE-$CONF` | Format (ONE new line at the end): `-----BEGIN PRIVATE KEY-----\nMIIEvalueofGSuitePrivatekey\n-----END PRIVATE KEY-----\n`<BR>Found in the GCP Console json formatted key for your [GCP service account]. |
+   | `REGISTRY_USER`<BR>`REGISTRY_PASSWORD` | All | - [`ci.sh`]`-p` | Export these variables if you plan on pushing images to your container registry using the `ci.sh` script WITHOUT running `podman login` first. The script will login for you using the values in these variables. |
 
 ## Podman secrets
 

--- a/docs/typed-images.md
+++ b/docs/typed-images.md
@@ -2,7 +2,7 @@
 
 "Typed images" refer to the images which are built off [`bwdc-base`] and are
 specific to a Directory Connector type (also referred to as
-`$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE`) and a config file (which would map to
+`$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE`) and a config file (which would map to
 a `data.json` file in Bitwarden Directory Connector). These containers are the
 primary purpose/use case for this project.
 
@@ -14,7 +14,7 @@ files which are expected to be in the format of the type specific template
 Typed image Containerfiles all follow the same basic format:
 
 * Pull `FROM` [ghcr.io/hdub-tech/bwdc-base:$BWDC_VERSION].
-* Export the `BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE`.
+* Export the `BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE`.
 * Set various OCI labels/
 * Uses a non-privileged `bitwarden` user to:
   * Copy a `sync.json` file with the type specific sync settings (to be used in
@@ -153,7 +153,7 @@ you can take advantage of the previous example, which will speed up runtimes.
 ### build-typed-images.sh
 
 The [`build-typed-images.sh`] script will build one image per
-`$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE/*.conf` file, based on the option
+`$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE/*.conf` file, based on the option
 provided to the script. It is used under the hood by [`ci.sh`]. While `ci.sh`
 is the workhorse/recommended use case, this script is useful if you are just
 getting started and are testing this project to see if it works for your use
@@ -166,7 +166,7 @@ case, and you haven't set-up your own project with this project as a submodule
 * Script confirms the appropriate secrets are available (`BW_CLIENTID` and
   `BW_CLIENTSECRET`), based on the `SECRETS_MANAGER` setting in
   [`defaults.conf`]/`custom.conf`
-* For each `*.conf` file in the `$BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE`
+* For each `*.conf` file in the `$BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE`
   directory, `podman build` is executed:
   * supplying the `.conf` file with `--build-arg-file`
   * supplying the secrets with `--secret`
@@ -174,7 +174,7 @@ case, and you haven't set-up your own project with this project as a submodule
     (default), or as the `BDCC_VERSION` if `USE_BDCC_VERSION_FOR_TYPED=true` in
     `custom.conf`
   * supplying the name of the conf file (`CONFNAME`) with `--build-arg`
-  * tagging it as the `$IMAGE_NAMESPACE/bwdc-${BITWARDENCLI_DIRECTORY_CONNECTOR_TYPE}-${CONF_NAME}:${BWDC_<TYPE>_IMAGE_VERSION}`
+  * tagging it as the `$IMAGE_NAMESPACE/bwdc-${BITWARDENCLI_CONNECTOR_DIRECTORY_TYPE}-${CONF_NAME}:${BWDC_<TYPE>_IMAGE_VERSION}`
   * The Containerfile build process is described at [the top of this document]
 * A `podman run` usage statement is output, in case a user wants a quick way to
   see how to use the generated image.

--- a/docs/typed-images.md
+++ b/docs/typed-images.md
@@ -40,13 +40,13 @@ a [git submodule]. Please see [config-files.md] for details.
 
 ## Table of Contents
 
-* [Building AND running (`ci.sh`)](#building-and-running-cish)
+* [Building, pushing AND running (`ci.sh`)](#building-pushing-and-running-cish)
   * [Examples](#examples)
     * [WARNING](#warning)
     * [Build all images and run in test mode](#build-all-images-and-run-in-test-mode)
     * [Build all images and run in sync mode](#build-all-images-and-run-in-sync-mode)
     * [Run all containers in sync mode without building images or installing pre-requisites](#run-all-containers-in-sync-mode-without-building-images-or-installing-pre-requisites)
-    * [Only build all images](#only-build-all-images)
+    * [Only build and push all images](#only-build-and-push-all-images)
 * [Building](#building)
   * [build-typed-images.sh](#build-typed-imagessh)
     * [Examples](#examples-1)
@@ -58,15 +58,15 @@ a [git submodule]. Please see [config-files.md] for details.
   * [ci.sh](#cish)
   * [podman run](#podman-run)
 
-## Building AND running (`ci.sh`)
+## Building, pushing AND running (`ci.sh`)
 
 > [!TIP]
 > This is the ultimate and recommended way to use this project.
 
 The [`ci.sh`] was designed to be the only command a CI system needs to execute.
 It will verify dependencies are present and the necessary version and **_build
-and run_** all typed images, depending on the options sent to the script. A
-summary of the script is provided below.
+and/or push and/or run_** all typed images, depending on the options sent to the
+script. A summary of the script is provided below.
 
 > [!NOTE]
 > **_Building_** an image will result in `bwdc login` and `bwdc logout`
@@ -84,6 +84,7 @@ executed, if the options for that were specified.
 * Pulls in [`defaults.conf`], and then `custom.conf` for any overrides.
 * Builds all images for all configuration files for all supported Directory
   Connector types, if `-b` was specified.
+* Pushes all images to `IMAGE_NAMESPACE` if `-p` was specified.
 * Runs all containers in the specified `MODE`, if `-r MODE` was specified, where
   `MODE` is one of:
   * `config`: Runs each container, finishing the necessary configuration using
@@ -131,14 +132,20 @@ is too old).
 ./bitwarden-directory-connector-containers/ci.sh -s -r sync
 ```
 
-#### Only build all images
+#### Only build and push all images
 
 This is useful if you want to push the images to your own container registry so
 you can take advantage of the previous example, which will speed up runtimes.
 
+> [!CAUTION]
+> Ensure `IMAGE_NAMESPACE` is set to your registry/namespace in `custom.conf`!
+>
+> You must run `podman login` first OR export `REGISTRY_USER` and
+`REGISTRY_PASSWORD` in order for push to work.
+
 ```bash
-# ONLY build all images
-./bitwarden-directory-connector-containers/ci.sh -s -b
+# ONLY build and push all images
+./bitwarden-directory-connector-containers/ci.sh -s -b -p
 ```
 
 ## Building
@@ -212,7 +219,7 @@ statement at the top of the corresponding Containerfile.
 
 ### ci.sh
 
-Refer to the [Run all containers] example in the [Building and running
+Refer to the [Run all containers] example in the [Building, pushing and running
 (`ci.sh`)] section.
 
 ### podman run
@@ -223,7 +230,7 @@ at the top of the corresponding Containerfile.
 * [`gsuite/Containerfile`]
 
 <!-- Links -->
-[Building AND running (`ci.sh`)]: #building-and-running-cish
+[Building, pushing AND running (`ci.sh`)]: #building-pushing-and-running-cish
 [the top of this document]:       #typed-images
 [Run all containers]:             #run-all-containers-in-sync-mode-without-building-images-or-installing-pre-requisites
 [`bwdc-base`]:                   ./base-image.md

--- a/docs/typed-images.md
+++ b/docs/typed-images.md
@@ -98,7 +98,7 @@ executed, if the options for that were specified.
 > [!WARNING]
 > The following commands are listed as if this project was a submodule of your
 project. Omit the leading `bitwarden-directory-connector-containers` directory
-and add the option `-p $PWD` if you are still playing around and have not gotten
+and add the option `-d $PWD` if you are still playing around and have not gotten
 to that stage yet.
 
 #### Build all images and run in test mode


### PR DESCRIPTION
## Description

> [!CAUTION]
> NON-BACKWARDS COMPATIBLE CHANGES INTRODUCED

This PR: 
- Fixes #31 
- Fixes #35 , with breaking changes:
  - ci.sh option `-p DIR` renamed to `-d DIR` (so `-p` could be used for `push`)
  - `IMAGE_NAMESPACE` defaults.conf value changed to `localhost`
- Fixes #34 

## Testing 

### ci.sh 

- [x] `ci.sh -p` will push images if already logged into registry and will not attempt to logout when done
    <details>
    
    ![Screenshot from 2025-02-13 13-59-27](https://github.com/user-attachments/assets/1eeff513-305d-4ef4-b6cb-617674769e9b)
    </details>

- [x] `ci.sh -p` will push images if able to login using REGISTRY_USER/REGISTRY_PASSWORD and will logout when done, regardless of error
    <details>
    
    ![Screenshot from 2025-02-13 14-01-39](https://github.com/user-attachments/assets/4b906e37-f940-4fca-bde0-5dfc44bc3daa)
    </details>
    
- [x] `ci.sh -p` will fail if not logged into registry and env vars not set appropriately
    <details>
    
    ![Screenshot from 2025-02-12 16-32-13](https://github.com/user-attachments/assets/7768b095-77f9-4ca1-a621-8752c9ede52e)
    </details>
    
- [x] `ci.sh -p` will not attempt to push images w/ a diff IMAGE_NAMESPACE (even though they are tagged from something that matches)
    <details>
    
    ![image](https://github.com/user-attachments/assets/ab5c70df-9995-43c5-bf08-46eaab283f31)
    </details>
    
- [x] `ci.sh -p` will NOT attempt to push images if IMAGE_NAMESPACE is localhost
    <details>
    
    ![Screenshot from 2025-02-12 17-35-17](https://github.com/user-attachments/assets/7cd3ac8a-1192-47d3-92de-18405bf6c584)
    </details>

- [x] REGRESSION: `-p DIR` renamed to `-d DIR`
    <details>
    
    ![Screenshot from 2025-02-12 14-50-10](https://github.com/user-attachments/assets/d368b33d-508c-4168-9b97-596ee2ba633c)
    ![Screenshot from 2025-02-12 14-57-33](https://github.com/user-attachments/assets/79eefb48-5e8d-4eb0-baed-8101fdc84d59)
    </details>
    

### Sample workflows

- [x] build-all-typed-images.yml
    <details>
    
    ![image](https://github.com/user-attachments/assets/8719311f-2773-4326-8c1c-8804c3d2aa90)
    </details>
    
- [x] build-and-push-all-typed-images.yml
    <details>
    
    ![image](https://github.com/user-attachments/assets/1f410a69-8bb5-4c5b-aa86-cec9489f4ae0)
    ![image](https://github.com/user-attachments/assets/03fbe77a-2aad-4de0-b93a-82360a1b2303)
    </details>
    
- [x] run-all-typed-images.yml
    <details>
    
    ![image](https://github.com/user-attachments/assets/0b18db96-4697-48a4-8633-ce2c810cb212)
    ![image](https://github.com/user-attachments/assets/6a64c715-bbf5-401c-bd7c-174a934f3bd2)
    </details>

### #34 

- [x] Docs no longer have wrong variable
   <details>
   
   ![image](https://github.com/user-attachments/assets/33839bdb-cc8d-47f5-9d86-84ed0aab9c4a)
   </details>
