### PR TITLE
Completes #40 (bwdc test --pretty) / Release BDCC 1.1.0 / misc things

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+# Description
+
+<!-- UNCOMMENT OR DELETE
+> [!CAUTION]
+> NON-BACKWARDS COMPATIBLE CHANGES INTRODUCED
+-->
+
+This PR:
+
+- Fixes #
+- DOES_A_NON_ISSUED_THING
+
+# Testing
+
+## SCRIPT_OR_CONTAINER_OR_ISSUE
+
+- [ ] `script` will DO_A_THING_NOW
+   <details>
+
+   PICTURE_OR_TEXT
+   </details>
+
+## Workflows
+
+- [ ] WORKFLOW_NAME
+   <details>
+
+   PICTURE_OR_TEXT
+   </details>
+
+# Documentation
+
+- [ ] Updated DOC.md
+- [ ] Created DOC.md

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -2,7 +2,7 @@ name: Build
 description: Build bwdc-base image
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,3 +3,7 @@ MD025: false
 
 # MD031/blanks-around-fences : Fenced code blocks should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md031.md
 MD031: false
+
+# MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.37.4/doc/md033.md
+MD033:
+  allowed_elements: [details, br, ul, li]

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Please see the [SECURITY.md] guide for details.
 [typed-images.md]:                  ./docs/typed-images.md
 [`bwdc`]:                           https://bitwarden.com/help/directory-sync-cli
 [Directory Connector]:              https://github.com/bitwarden/directory-connector
-[`directory-connector` issues]:     https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues?q=is%3Aissue%20state%3Aopen%20label%3Adirectory-connector
+[`directory-connector` issues]:     https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Component%3A%20directory-connector%22
 [Discussions]:                      https://github.com/hdub-tech/bitwarden-directory-connector-containers/discussions
 [`ENTRYPOINT`]:                     https://docs.podman.io/en/latest/markdown/podman-run.1.html#entrypoint-command-command-arg1
 [GitHub packages for this project]: https://github.com/users/hdub-tech/packages?repo_name=bitwarden-directory-connector-containers

--- a/README.md
+++ b/README.md
@@ -236,6 +236,5 @@ Please see the [SECURITY.md] guide for details.
   MD013: {
     code_blocks: false
   },
-  MD033: false
 }
 -->

--- a/defaults.conf
+++ b/defaults.conf
@@ -10,7 +10,7 @@ BWDC_VERSION=2025.1.0
 # The release of bitwarden-directory-connector-containers / latest bwdc-base tag
 # Only modify this if you are a maintainer doing a release OR you are a user
 # using USE_BDCC_VERSION_FOR_TYPED=true and you want an older release.
-BDCC_VERSION=1.0.0
+BDCC_VERSION=1.1.0
 
 # Uncomment the following if you want to lock to the BDCC_VERSION of bwdc-base
 # in the typed containers, as opposed to the default behavior of using the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -39,8 +39,3 @@ declined, etc.
 <!-- Links -->
 [Issue #13]:     https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/13
 [open an issue]: https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/new/choose
-
-<!-- markdownlint-configure-file {
-  MD033: false
-}
--->

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -149,8 +149,3 @@ corresponding `data.json` values, refer to the `jq` command in the
 [Google Workspace > Connect to your directory]: https://bitwarden.com/help/workspace-directory/#connect-to-your-directory
 [Semantic versioning]:                          https://semver.org
 [the first real bug]:                           https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/27
-
-<!-- markdownlint-configure-file {
-  MD033: false
-}
--->

--- a/docs/managing-secrets.md
+++ b/docs/managing-secrets.md
@@ -78,6 +78,5 @@ full details on how I got in this pickle.
   MD013: {
     code_blocks: false
   },
-  MD033: false
 }
 -->

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,11 +22,11 @@ usage() {
     ${SCRIPT_NAME} [-c] [-t] [-s] [-h]
 
   Where at least one of the following is required:
-    * -c: (aka config) - Configures data.json with env var secrets. (Use this
+    * -c: (aka config) - Configures data.json with env var secrets (Use this
                          option when using the config file method, or the BYO
                          data.json method and the data.json does not contain
                          secrets. Omit this option if using your own data.json
-                         and it already has the secrets populated)
+                         and it already has the secrets populated).
     * -t: (aka test)   - Runs "bwdc test", with bwdc login if necessary, and
                          bwdc logout when completed (even if error).
     * -s: (aka sync)   - Runs "bwdc sync", with bwdc login if necessary, and
@@ -82,7 +82,7 @@ logout() {
 
 preReqs() {
   # Make sure we have bwdc for all modes
-  if which bwdc; then
+  if which bwdc &>/dev/null; then
     BW_DATAFILE="$( bwdc data-file 2>/dev/null )"
   
     # Make sure Client Id and Secret set in env vars for login

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -150,7 +150,7 @@ config() {
 
 bwdcTest() {
   login
-  bwdc test || test_failed=true
+  bwdc test --pretty || test_failed=true
   # Always logout
   logout
 


### PR DESCRIPTION
# Description

This PR:
* Fixes #40
* Cleans up entrypoint.sh output
* Fixes a link in docs
* Bumps BDCC_VERSION for a release 
* Completes #22 
* Promote MD033 from being individually excluded to being in the conf file
* Build and Lint workflows flipped to run in context of branch (External contributors require actions to be approved for the security portion)

# Testing

## entrypoint.sh

- [x] `entrypoint.sh` will display pretty json output for `bwdc test` and no longer output `bdwc` path
   <details>

   ![Screenshot from 2025-02-18 13-18-28](https://github.com/user-attachments/assets/69c10eec-3583-46aa-a386-b840ff2be78e)
   </details>

## Release

- [x] Successful local bwdc-base build
   <details>
   
   ![image](https://github.com/user-attachments/assets/4dc404e1-b088-4243-86ec-d74078ee2110)
   </details>
# Documentation

- [x] Updated all markdown files excluding MD033
- [x] Fixed README.md link to `directory-connector` labelled Issues
