### PR TITLE
Fixes #49: Support bwdc version 2025.5.0

### DIFF
--- a/defaults.conf
+++ b/defaults.conf
@@ -5,12 +5,12 @@
 # when building typed images, the version of the bwdc-base image to pull from
 # https://github.com/hdub-tech?tab=packages&repo_name=bitwarden-directory-connector-containers
 # (See docs/base-image.md, docs/typed-images.md)
-BWDC_VERSION=2025.1.0
+BWDC_VERSION=2025.5.0
 
 # The release of bitwarden-directory-connector-containers / latest bwdc-base tag
 # Only modify this if you are a maintainer doing a release OR you are a user
 # using USE_BDCC_VERSION_FOR_TYPED=true and you want an older release.
-BDCC_VERSION=1.1.0
+BDCC_VERSION=1.2.0
 
 # Uncomment the following if you want to lock to the BDCC_VERSION of bwdc-base
 # in the typed containers, as opposed to the default behavior of using the


### PR DESCRIPTION
# Description

<!-- UNCOMMENT OR DELETE
> [!CAUTION]
> NON-BACKWARDS COMPATIBLE CHANGES INTRODUCED
-->

This PR:

- Fixes #49

# Testing

## build-base-image.sh / bwdc-base image

- [x] `./build-base-image.sh -c` will build a `bwdc-base` image containing bwdc version `2025.5.0`
   <details>
    
    ![image](https://github.com/user-attachments/assets/740ffa55-ea61-4aac-b824-771fe5c1a1ec)
    
    ![Screenshot from 2025-05-28 14-05-36](https://github.com/user-attachments/assets/4e41e101-24ae-4dd7-a2f2-73e3594bafaa)

   ![Screenshot from 2025-05-28 14-08-31](https://github.com/user-attachments/assets/81816e49-13ca-44bd-bf48-e4a36c8cde18)

   </details>


