### PR TITLE
Script to update BDCC_VERSION script and create release branch

### DIFF
--- a/.github/workflows/update-bdcc-version-branch.sh
+++ b/.github/workflows/update-bdcc-version-branch.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Constants / Globals
+SCRIPT_DIR="$( cd "$( dirname "${0}" )" && pwd )"
+SCRIPT_NAME="$( basename "${0}" )"
+PROJECT_DIR=$( cd "${SCRIPT_DIR}/../../" && pwd )
+SUPPORTED_BWDC_TYPES=( gsuite )
+FILES_TO_UPDATE=( defaults.conf gsuite/argfile.conf.template docs/config-files.md )
+# shellcheck disable=SC1091
+. "${PROJECT_DIR}"/functions.sh
+
+# Configurable args
+NEW_BDCC_VERSION=
+RELEASE_BRANCH=
+
+usage() {
+   cat <<EOM
+
+  DESCRIPTION:
+    A script which will create a release branch, sed update the BDCC_VERSION in
+    the relevant files, then run git add, git commit and git push. Current
+    files being updated:
+$( for file in "${FILES_TO_UPDATE[@]}"; do echo "    - $file"; done; )
+
+  USAGE:
+    ${0} -v NEW_BDCC_VERSION [-h]
+
+  Where:
+    * -h: Displays this help statement
+    * -v NEW_BDCC_VERSION: REQUIRED. The new version number of bdcc. Do NOT
+     include the leading 'v'
+EOM
+  exit "${1}"
+}
+
+sedUpdates() {
+  # Update BDCC_VERSION in defaults.conf
+  sed -i'' "/^BDCC_VERSION/s|=.*|=${NEW_BDCC_VERSION}|" "${PROJECT_DIR}/defaults.conf" || exit 3
+  
+  # Update BWDC_$TYPE_IMAGE_VERSION argfile.conf.template
+  for type in "${SUPPORTED_BWDC_TYPES[@]}"; do
+    sed -i'' "/IMAGE_VERSION=/s|=.*-|=${NEW_BDCC_VERSION}-|" "${PROJECT_DIR}/${type}/argfile.conf.template" || exit 4
+  done
+  
+  # Update git blurbs in config-files.md
+  sed -i'' "/^git checkout/s|v[0-9\.]*|v${NEW_BDCC_VERSION}|" "${PROJECT_DIR}/docs/config-files.md" || exit 5
+  sed -i'' "/^git commit.*Set/s|v[0-9\.]*|v${NEW_BDCC_VERSION}|" "${PROJECT_DIR}/docs/config-files.md" || exit 6
+}
+
+while getopts "v:h" opt; do
+  case "${opt}" in
+    "v")
+      # v = version (new)
+      NEW_BDCC_VERSION="${OPTARG}"
+      ;;
+    "h" )
+      # h = help
+      usage 0 ;;
+    * ) usage 1 ;;
+  esac
+done
+
+if [ -z "${NEW_BDCC_VERSION}" ]; then
+  usage 2
+else
+  RELEASE_BRANCH="release/${NEW_BDCC_VERSION}"
+  message "${SCRIPT_NAME}" "INFO" "Creating branch [${RELEASE_BRANCH}]"
+  git checkout -b "${RELEASE_BRANCH}" || exit 7
+
+  message "${SCRIPT_NAME}" "INFO" "Updating to BDCC_VERSION [${NEW_BDCC_VERSION}] in [${FILES_TO_UPDATE[*]}] using sed"
+  sedUpdates
+
+  message "${SCRIPT_NAME}" "INFO" "Changes:"
+  git diff || exit 8
+
+  message "${SCRIPT_NAME}" "INFO" "Adding updated files to [${RELEASE_BRANCH}]"
+  cd "${PROJECT_DIR}" && git add "${FILES_TO_UPDATE[@]}" || exit 9
+
+  message "${SCRIPT_NAME}" "INFO" "Commiting updated files to [${RELEASE_BRANCH}]"
+  git commit -m "Bump BDCC_VERSION to ${NEW_BDCC_VERSION}" || exit 10
+
+  message "${SCRIPT_NAME}" "INFO" "Pushing branch [${RELEASE_BRANCH}]"
+  git push || exit 11
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,46 @@
-# CONTRIBUTING (WIP)
+# CONTRIBUTING (_WIP_)
 
 ## Issues and PRs welcome!!
 
-_[Issue #6]: Add Code of Conduct stuff. In the meantime, be good to each other or
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Initial set-up](#initial-set-up)
+  - [Sign and Sign Off on commits](sign-and-sign-off-on-commits)
+  - [Linting](#linting)
+- [Releases](#releases)
+
+## Code of Conduct
+
+_[Issue #7]: Add Code of Conduct stuff. In the meantime, be good to each other or
 I will banhammer you. You will have one opportunity to apologize for bad
-behavior, and then you are gone._
+behavior or you are gone._
 
-_[Issue #7]: Add [DCO]_
+## Initial set-up
 
-> [!TIP]
-> Signing (`Verified` tag) and Signing off on (`Signed-Off-by`) your commits is
-required. HOWEVER, unlike most projects which require this, [@hdub-tech] will
-NEVER require your real name be in the `Signed-Off-by` line. We firmly believe
-you should be able to contribute to open source AND maintain your privacy.
+In addition to cloning this project and installing the [Requirements], it is
+recommended you do the things in the next few sections.
 
-## Linting
+### Sign and Sign Off on commits
 
-This project contains a [Linting workflow] which will kick off when PRs are
-opened. This workflow executes the [pre-commit.sh] script. It is HIGHLY
-recommended that you link the `.github/pre-commit.sh` to
-`.git/hooks/pre-commit.sh` so that this script will execute for you locally
-before you even get to the PR stage.
+_[Issue #6]: Add [DCO]_
+
+[Signing] (`Verified` tag / `git commit -S`) and [Signing off] (`Signed-Off-by`
+in agreement with DCO / `git commit --signoff|-s`) on your commits is required.
+HOWEVER, unlike most projects which require this, [@hdub-tech] will NEVER
+require your real name to be in the `Signed-Off-by` line. We firmly believe you
+should be able to contribute to open source AND maintain your privacy.
+
+### Linting
+
+All commits must pass the linter. This project contains a [Linting workflow]
+which will kick off when PRs are opened. This workflow executes the
+[pre-commit.sh] script. It is HIGHLY recommended that you link the
+`.github/pre-commit.sh` to `.git/hooks/pre-commit.sh` so that this script will
+execute for you locally before you even get to the PR stage.
 
 ```bash
+# From the bitwarden-directory-connector-containers directory
 mkdir .git/hooks  # If necessary
 ln -s -r .github/pre-commit.sh .git/hooks/pre-commit
 ```
@@ -98,15 +116,18 @@ ln -s -r .github/pre-commit.sh .git/hooks/pre-commit
 [Linting workflow]:                ./.github/workflows/lint.yml
 [pre-commit.sh]:                   ./.github/pre-commit.sh
 [`update-bdcc-version-branch.sh`]: ./.github/workflows/update-bdcc-version-branch.sh
-[DCO]:              https://developercertificate.org/_
-[@hdub-tech]:       https://github.com/hdub-tech
-[Issue #6]:         https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/6
-[Issue #7]:         https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/7
+[DCO]:                 https://developercertificate.org/
+[@hdub-tech]:          https://github.com/hdub-tech
 [Build/Push]:          https://github.com/hdub-tech/bitwarden-directory-connector-containers/actions/workflows/build-push-base.yml
+[Issue #6]:            https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/6
+[Issue #7]:            https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/7
 [Issue #39]:           https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/39
 [new release]:         https://github.com/hdub-tech/bitwarden-directory-connector-containers/releases/new
 [pull request]:        https://github.com/hdub-tech/bitwarden-directory-connector-containers/pulls
+[Requirements]:        https://github.com/hdub-tech/bitwarden-directory-connector-containers/blob/main/README.md#requirements
 [Semantic versioning]: https://semver.org/
+[Signing]:             https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+[Signing off]:         https://git-scm.com/docs/git-commit#Documentation/git-commit.txt-code--signoffcode
 
 <!-- markdownlint-configure-file {
   MD026: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,86 @@ mkdir .git/hooks  # If necessary
 ln -s -r .github/pre-commit.sh .git/hooks/pre-commit
 ```
 
+## Releases
+
+> [!NOTE]
+> _There is a pending todo ([Issue #39] to convert this section to a workflow._
+<!-- markdownlint-disable-next-line no-blanks-blockquote -->
+> [!IMPORTANT]
+> _This assumes you have already built and tested the base container as
+> described in [docs/base-image.md#How]._
+
+1. Determine the next version number for `BDCC_VERSION` using [Semantic versioning].
+
+   ```bash
+   # Do not include a leading 'v'! Example:
+   export NEW_BDCC_VERSION=1.2.3
+   ```
+
+2. Ensure you are at the root of the project on the main branch with all
+   relevant code merged to main.
+
+   ```bash
+   cd /PATH/TO/bitwarden-directory-connector-containers
+   git checkout main
+   ```
+
+3. Run the [`update-bdcc-version-branch.sh`] script to create a release branch,
+   update `BDCC_VERSION` in all the necessary places, git add and commit the
+   changed files, and push the `release/$NEW_BDCC_VERSION` branch to remote.
+
+   ```bash
+   ./.github/workflows/update-bdcc-version-branch.sh -v $NEW_BDCC_VERSION
+   ```
+
+4. Open a [pull request] for the `release/$NEW_BDCC_VERSION` branch and merge
+   it to main.
+
+5. Run the [Build/Push] workflow to publish the new `bwdc-base` image.
+
+6. Draft a [new release] with the following settings:
+
+   a. Choose a tag: Type in `v$NEW_BDCC_VERSION` (Example: `v1.2.3`), and
+      choose "Create new tag on publish".
+
+   b. Target: `main`
+
+   c. Previous tag: `auto`
+
+   d. Click the button for "Generate release notes" (The Release Title field
+      should now match the Tag).
+
+   e. Change the `in FULL_PR_LINK` to just `(#xyz)` in each bullet in the
+      "What's changed" section.
+
+   f. Add the following blurb (updating `$PKG_ID`, `$NEW_BDCC_VERSION` and
+      `BWDC_VERSION`):
+
+      <!-- markdownlint-disable MD013 -->
+      ```markdown
+      ## Assets
+
+      Latest [`bwdc-base` package](https://github.com/hdub-tech/bitwarden-directory-connector-containers/pkgs/container/bwdc-base/$PKG_ID?tag=$NEW_BDCC_VERSION) tagged with: `$NEW_BDCC_VERSION` and `$BWDC_VERSION`
+      ```
+      <!-- markdownlint-enable MD013 -->
+   g. Check the box for "Set as the latest release".
+
+   h. Click the "Publish release" button.
+
 <!-- Links -->
-[Linting workflow]: ./.github/workflows/lint.yml
-[pre-commit.sh]:    ./.github/pre-commit.sh
+[docs/base-image.md#How]:          ./docs/base-image.md#How
+[Linting workflow]:                ./.github/workflows/lint.yml
+[pre-commit.sh]:                   ./.github/pre-commit.sh
+[`update-bdcc-version-branch.sh`]: ./.github/workflows/update-bdcc-version-branch.sh
 [DCO]:              https://developercertificate.org/_
 [@hdub-tech]:       https://github.com/hdub-tech
 [Issue #6]:         https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/6
 [Issue #7]:         https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/7
+[Build/Push]:          https://github.com/hdub-tech/bitwarden-directory-connector-containers/actions/workflows/build-push-base.yml
+[Issue #39]:           https://github.com/hdub-tech/bitwarden-directory-connector-containers/issues/39
+[new release]:         https://github.com/hdub-tech/bitwarden-directory-connector-containers/releases/new
+[pull request]:        https://github.com/hdub-tech/bitwarden-directory-connector-containers/pulls
+[Semantic versioning]: https://semver.org/
 
 <!-- markdownlint-configure-file {
   MD026: false

--- a/docs/base-image.md
+++ b/docs/base-image.md
@@ -17,6 +17,7 @@ the [BYO data.json method], you can skip directly to that section below.
   - [When](#when)
   - [Requirements](#requirements)
   - [How](#how)
+  - [Releasing](#releasing)
 - [Published Image](#published-image)
 - [BYO data.json method](#byo-datajson-method)
   - [What the `${SECRETS}`?](#what-the-secrets)
@@ -79,6 +80,10 @@ some screenshots and/or keep your test commands!
 5. Open a PR to bump the version. Document how you tested. Ensure the Actions
    for your PR passed.
 <!-- markdownlint-enable blanks-around-lists ol-prefix -->
+
+### Releasing
+
+Refer to [CONTRIBUTING.md#releases] for the release process.
 
 ## Published image
 
@@ -203,6 +208,7 @@ related tickets ([LDAP], [Azure], [OneLogin], [Okta])!
 [`bwdc-base` image]:     ../Containerfile
 [config file method]:    ./creating-configs.md
 [CONTRIBUTING.md]:       ../CONTRIBUTING.md
+[CONTRIBUTING.md#releases]: ../CONTRIBUTING.md#releases
 [`defaults.conf`]:       ../defaults.conf
 [`entrypoint.sh`]:       ../entrypoint.sh
 [managing-secrets.md]:   ./managing-secrets.md


### PR DESCRIPTION
# Description

This PR:

- Resolves #53
- Improves CONTRIBUTING.md

# Testing

## update-bdcc-version-branch.sh

- [x] `update-bdcc-version-branch.sh` without arguments exits with error and prints usage
   <details>

   ![Screenshot from 2025-06-05 13-59-23](https://github.com/user-attachments/assets/9a74f87c-ca43-419b-94dc-855aec90ab71)

   </details>

- [x] `update-bdcc-version-branch.sh -h` exits without error and prints usage
   <details>

   ![Screenshot from 2025-06-05 13-59-46](https://github.com/user-attachments/assets/ce6804aa-b196-4913-82e0-3e73a7477c02)

   </details>

- [x] `update-bdcc-version-branch.sh -v $NEW_BDCC_VERSION` creates a release branch, updates BDCC_VERSION in all the places, adds and commits the changed files, and pushes the branch.
   <details>

   [!NOTE] _Technically the push failed here because I don't have push.autoSetupRemote set (yeah yeah I know). Technically that means I don't know if the push step works. I'm gonna run that risk watch my release PR have a fix for it now_

   ![image](https://github.com/user-attachments/assets/693c2f11-d71d-4022-8c7f-28e79af0ace9)

   </details>

# Documentation

- [x] Updated CONTRIBUTING.md to include a release process (also general clean-up)
- [x] Updated base-image.md to reference the new Release section
